### PR TITLE
Duplicate assert

### DIFF
--- a/api/sphinxapi.php
+++ b/api/sphinxapi.php
@@ -852,8 +852,6 @@ class SphinxClient
 	function SetFilter ( $attribute, $values, $exclude=false )
 	{
 		assert ( is_string($attribute) );
-		assert ( is_array($values) );
-		assert ( count($values) );
 
 		if ( is_array($values) && count($values) )
 		{

--- a/api/sphinxapi.php
+++ b/api/sphinxapi.php
@@ -852,8 +852,9 @@ class SphinxClient
 	function SetFilter ( $attribute, $values, $exclude=false )
 	{
 		assert ( is_string($attribute) );
+		assert ( is_array($values) );
 
-		if ( is_array($values) && count($values) )
+		if ( count($values) )
 		{
 			foreach ( $values as $value )
 				assert ( is_numeric($value) );


### PR DESCRIPTION
Duplication of conditions.
$values must be array but can be empty
